### PR TITLE
Add regex format for US ZIP codes

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -8168,7 +8168,8 @@
             },
             {
               "postalcode": {
-                "label": "ZIP code"
+                "label": "ZIP code",
+                "format": "^\\d{5}(?:[-\\s]\\d{4})?$"
               }
             }
           ]


### PR DESCRIPTION
This one's [pretty well-documented](http://en.wikipedia.org/wiki/ZIP_code).  US ZIP codes consist of 5 digits.  Optionally, 4 additional digits can be affixed to the 5 primary digits (separated by a hyphen).  Believe checking that a zip code exists is beyond the scope of this configuration.

**Proposed pattern**
`^\d{5}(?:[-\s]\d{4})?$`

**Examples**
- 98103
- 90210-9998
