### PR TITLE
Add regex format for Canadian postal codes

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -1333,7 +1333,8 @@
             },
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^[ABCEGHJKLMNPRSTVXY]\\d[ABCEGHJ-NPRSTV-Z][ ]?\\d[ABCEGHJ-NPRSTV-Z]\\d$"
               }
             }
           ]


### PR DESCRIPTION
Another relatively straightforward one, [data from here](http://i18napis.appspot.com/address/data/CA). [Wikipedia](http://en.wikipedia.org/wiki/Postal_codes_in_Canada) backs up the format (e.g. `A1A 1A1`), with a few caveated letters.

**Proposed format**
`^[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ ]?\d[ABCEGHJ-NPRSTV-Z]\d$`

**Examples**
- H3Z 2Y7
- V8X 3X4
