### PR TITLE
Add Indian postal code format string

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -3335,7 +3335,8 @@
             },
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{6}$"
               }
             }
           ]


### PR DESCRIPTION
Very straightforward. Indian postal codes consist of 6 digits only. [Data from Google](http://i18napis.appspot.com/address/data/IN). 

**Proposed format**
`^\d{6}$`

**Examples**
- 110034
- 110001
