### PR TITLE
Add Australia postal code format

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -433,7 +433,8 @@
             },
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "\\d{4}"
               }
             }
           ]


### PR DESCRIPTION
Very straightforward. Australian postal codes consist of 4 digits only. [Data from Google](http://i18napis.appspot.com/address/data/AU). 

**Proposed format**
`^\d{4}$`

**Examples**
- 2055
- 1235
