### PR TITLE
Add postal code format for France

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2448,7 +2448,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{2}[ ]?\\d{3}$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. French postal codes consist of 5 digits only. Optionally, the first two digits can be separated from the next three digits with whitespace. [Data from Google](http://i18napis.appspot.com/address/data/FR). 

**Proposed format**
`^\\d{2}[ ]?\\d{3}$`

**Examples**
- 33380
- 34 092
