### PR TITLE
Adding postal code format for Germany

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2659,7 +2659,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{5}$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. German postal codes consist of 5 digits only. [Data from Google](http://i18napis.appspot.com/address/data/DE). 

**Proposed format**
`^\d{5}$`

**Examples**
- 26133
- 53225
