### PR TITLE
Adding postal code format for Brazil

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -1025,7 +1025,8 @@
             },
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{5}[\\-]?\\d{3}$"
               }
             }
           ]


### PR DESCRIPTION
Very straightforward. Brazilian postal codes consist of 8 digits, optionally separated by a hyphen after the first 5 digits. [Data from Google](http://i18napis.appspot.com/address/data/BR). 

**Proposed format**
`^\d{5}[\\-]?\d{3}$`

**Examples**
- 40301-110
- 70002900
