### PR TITLE
Adding postal code format for Mexico

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -5036,7 +5036,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{5}$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. Mexican postal codes consist of 5 digits only. [Data from Google](http://i18napis.appspot.com/address/data/MX). 

**Proposed format**
`^\d{5}$`

**Examples**
- 02860
- 77520
