### PR TITLE
Adding Japanese postal code format

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -3980,7 +3980,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{3}-?\\d{4}$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. Japanese postal codes consist of 7 digits, optionally separating the first three digits from the last four with a hyphen . [Data from Google](http://i18napis.appspot.com/address/data/JP). 

**Proposed format**
`^\d{3}-?\d{4}$$`

**Examples**
- 154-0023
- 350-1106
