### PR TITLE
Adding postal code format for the Netherlands

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -5438,7 +5438,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}[ ]?[A-Z]{2}$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. Dutch postal codes consist of 4 digits followed by two upper-case alpha characters, optionally separated by a space. [Data from Google](http://i18napis.appspot.com/address/data/NL). 

**Proposed format**
`^\d{4}[ ]?[A-Z]{2}$`

**Examples**
- 1234 AB
- 2490 AA
