### PR TITLE
Adding postal code format for Singapore

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6870,7 +6870,8 @@
             },
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{6}$"
               }
             }
           ]


### PR DESCRIPTION
Very straightforward. Sinagpore postal codes consist of 6 digits only. [Data from Google](http://i18napis.appspot.com/address/data/SG). 

**Proposed format**
`^\d{6}$`

**Examples**
- 546080
- 308125
