### PR TITLE
Add postal code format for Argentina

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -299,7 +299,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^((?:[A-HJ-NP-Z])?\\d{4})([A-Z]{3})?$"
               }
             },
             {


### PR DESCRIPTION
This one's a little interesting. Somewhat similar to the ZIP+4 update to the US postal code system in the 1980s...  Argentina updated its postal code system in 1998.  The old format was a simple 4-digit code.  The new code includes a single letter at the beginning, representing the province, and then three letter following the 4 digits, representing the side of the block where the address is located.

This format switch is still an ongoing process; it's not adopted 100% of private citizens, let alone businesses.

The proposed format below supports both the old format, as well as the new. Again, [data from Google](http://i18napis.appspot.com/address/data/AR). 

**Proposed format**
`^((?:[A-HJ-NP-Z])?\d{4})([A-Z]{3})?$`

**Examples**
- 1900
- B6000
- X5187XAB
