### PR TITLE
Adding postal code format for China

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -1502,7 +1502,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{6}$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. Chinese postal codes consist of 6 digits only. [Data from Google](http://i18napis.appspot.com/address/data/CN). 

**Proposed format**
`^\d{6}$`

**Examples**
- 266033
- 317204
