### PR TITLE
Adding postal code format for Taiwan

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7425,7 +7425,8 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{3}(\\d{2})?$"
               }
             },
             {


### PR DESCRIPTION
Very straightforward. Taiwanese postal codes consist of 5 digits only; typically only the first three digits are required. The last two digits refer to a more detailed level of locale and are typically optional.  [Data from Google](http://i18napis.appspot.com/address/data/TW). 

**Proposed format**
`^\d{3}(\d{2})?$`

**Examples**
- 106
- 10603
