### PR TITLE
Adding postal code support for Afghanistan

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -21,6 +21,13 @@
               "localityname": {
                 "label": "City"
               }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "1001"
+              }
             }
           ]
         }


### PR DESCRIPTION
Postal codes were introduced in Afghanistan in March of 2011; they consist of four digits (with more precise meaning, but 4 digits should be sufficient for our validation).

Source: http://mcit.gov.af/en/news/874
