### PR TITLE
Updating Suriname labels

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -8525,7 +8525,7 @@
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Province"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
