### PR TITLE
Updating San Marino labels

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7731,11 +7731,6 @@
               "localityname": {
                 "label": "City"
               }
-            },
-            {
-              "administrativearea": {
-                "label": "State"
-              }
             }
           ]
         }


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
