### PR TITLE
Updating labels for Seychelles

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7871,6 +7871,11 @@
               "localityname": {
                 "label": "City"
               }
+            },
+            {
+              "administrativearea": {
+                "label": "Island"
+              }
             }
           ]
         }


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
