### PR TITLE
Updating labels for Puerto Rico

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7059,13 +7059,8 @@
               }
             },
             {
-              "administrativearea": {
-                "label": "State"
-              }
-            },
-            {
               "postalcode": {
-                "label": "Postal code"
+                "label": "ZIP code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
