### PR TITLE
Updating labels for the Philippines

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6929,8 +6929,8 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
+              "dependent_localityname": {
+                "label": "Suburb"
               }
             },
             {
@@ -6940,7 +6940,12 @@
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Province"
+              }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
