### PR TITLE
Updating labels for Papua New Guinea

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6749,18 +6749,18 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
-              }
-            },
-            {
               "localityname": {
                 "label": "City"
               }
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Province"
+              }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
