### PR TITLE
Updating Nicaragua labels

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6345,7 +6345,7 @@
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Department"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
