### PR TITLE
Updating labels for Nigeria

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6399,11 +6399,6 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
-              }
-            },
-            {
               "localityname": {
                 "label": "City"
               }
@@ -6411,6 +6406,11 @@
             {
               "administrativearea": {
                 "label": "State"
+              }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
