### PR TITLE
Updating labels for Kazakhstan

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -4801,7 +4801,7 @@
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Province"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
