### PR TITLE
Updating labels for the Cayman Islands

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -1479,13 +1479,13 @@
         {
           "locality": [
             {
-              "localityname": {
-                "label": "City"
+              "postalcode": {
+                "label": "Postal code"
               }
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Island"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
