### PR TITLE
Updating labels for South Korea

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -8191,8 +8191,8 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
+              "dependent_localityname": {
+                "label": "District"
               }
             },
             {
@@ -8202,7 +8202,7 @@
             },
             {
               "administrativearea": {
-                "label": "State",
+                "label": "Province",
                 "options": [
                   {
                     "": "--"
@@ -8259,6 +8259,11 @@
                     "Sejong": "Sejong"
                   }
                 ]
+              }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
