### PR TITLE
Updating labels for Saint Kitts and Nevis

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7572,18 +7572,13 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
-              }
-            },
-            {
               "localityname": {
                 "label": "City"
               }
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Island"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
