### PR TITLE
Updating labels for Kiribati

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -4861,7 +4861,7 @@
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Island"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
