### PR TITLE
Updating Gibraltar labels

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2952,11 +2952,6 @@
               "postalcode": {
                 "label": "Postal code"
               }
-            },
-            {
-              "localityname": {
-                "label": "City"
-              }
             }
           ]
         }


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
