### PR TITLE
Updating labels for Egypt

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2393,6 +2393,11 @@
                   }
                 ]
               }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code"
+              }
             }
           ]
         }


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
