### PR TITLE
Updating labels for Cape Verde

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -1457,6 +1457,11 @@
               "localityname": {
                 "label": "City"
               }
+            },
+            {
+              "administrativearea": {
+                "label": "Island"
+              }
             }
           ]
         }


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
