### PR TITLE
Updating labels for Cocos (Keeling) Islands

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -1819,13 +1819,18 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
+              "localityname": {
+                "label": "City"
               }
             },
             {
-              "localityname": {
-                "label": "City"
+              "administrativearea": {
+                "label": "Province"
+              }
+            },
+            {
+              "postalcode": {
+                "label": "Postal code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
