### PR TITLE
Updating labels for the Bahamas

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -611,7 +611,7 @@
             },
             {
               "administrativearea": {
-                "label": "State"
+                "label": "Island"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
