### PR TITLE
Updating labels for Brazil

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -999,7 +999,7 @@
       "fields": [
         {
           "thoroughfare": {
-            "label": "thoroughfare"
+            "label": "Thoroughfare"
           }
         },
         {
@@ -1008,12 +1008,12 @@
           }
         },
         {
-          "dependent_localityname": {
-            "label": "Neighborhood"
-          }
-        },
-        {
           "locality": [
+            {
+              "dependent_localityname": {
+                "label": "Neighborhood"
+              }
+            },
             {
               "localityname": {
                 "label": "City"


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
