### PR TITLE
Updating labels for American Samoa

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -135,13 +135,18 @@
         {
           "locality": [
             {
-              "postalcode": {
-                "label": "Postal code"
+              "localityname": {
+                "label": "City"
               }
             },
             {
-              "localityname": {
-                "label": "City"
+              "administrativearea": {
+                "label": "State"
+              }
+            },
+            {
+              "postalcode": {
+                "label": "ZIP code"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
