### PR TITLE
Adding postal code format constraint and example for Austria

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -556,7 +556,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "3741"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
