### PR TITLE
Adding postal code constraint and example for Aland Islands

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -56,7 +56,9 @@
             },
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^22\\d{3}$",
+                "eg": "22150"
               }
             }
           ]


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
