### PR TITLE
Adding postal code constraint and example for Belgium

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -770,7 +770,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "4000"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
