### PR TITLE
Adding postal code constraint and example for Saint Barthelemy

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7569,7 +7569,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^9[78][01]\\d{2}$",
+                "eg": "97100"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
