### PR TITLE
Adding postal code constraint and example for Switzerland

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -8717,7 +8717,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "2544"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
