### PR TITLE
Adding postal code constraint and example for Denmark

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2191,7 +2191,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "8660"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
