### PR TITLE
Adding postal code constraint and example for Finland

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2694,7 +2694,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{5}$",
+                "eg": "00550"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
