### PR TITLE
Adding postal code constraint and example for French Guiana

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -2758,7 +2758,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^9[78]3\\d{2}$",
+                "eg": "97300"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
