### PR TITLE
Adding postal code constraint and example for Guernsey

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -3202,7 +3202,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^GY\\d[\\dA-Z]?[ ]?\\d[ABD-HJLN-UW-Z]{2}$",
+                "eg": "GY1 1AA"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
