### PR TITLE
Adding postal code constraint and example for Greenland

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -3052,7 +3052,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^39\\d{2}$",
+                "eg": "3911"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
