### PR TITLE
Adding postal code constraint and example for Greece

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -3022,7 +3022,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{3} ?\\d{2}$",
+                "eg": "151 24"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
