### PR TITLE
Adding postal code constraint and example for the Isle of Man

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -4076,7 +4076,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^IM\\d[\\dA-Z]?[ ]?\\d[ABD-HJLN-UW-Z]{2}$",
+                "eg": "IM99 1PS"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
