### PR TITLE
Adding postal code constraint and example for Jersey

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -4798,7 +4798,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^JE\\d[\\dA-Z]?[ ]?\\d[ABD-HJLN-UW-Z]{2}$",
+                "eg": "JE2 2BT"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
