### PR TITLE
Adding postal code constraint and example for Liechtenstein

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -5200,7 +5200,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^(948[5-9])|(949[0-7])$",
+                "eg": "9496"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
