### PR TITLE
Adding postal code constraint and example for Martinique

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -5627,7 +5627,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^9[78]2\\d{2}$",
+                "eg": "97220"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
