### PR TITLE
Adding postal code constraint and example for New Caledonia

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6313,7 +6313,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^988\\d{2}$",
+                "eg": "98814"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
