### PR TITLE
Adding postal code constraint and example for Norway

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -6661,7 +6661,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "0025"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
