### PR TITLE
Adding postal code constraint and example for Poland

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7103,7 +7103,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{2}-?\\d{3}$",
+                "eg": "00-950"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
