### PR TITLE
Adding postal code constraint and example for Saint Pierre and Miquelon

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7748,7 +7748,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^9[78]5\\d{2}$",
+                "eg": "97500"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
