### PR TITLE
Adding postal code constraint and example for Portugal

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7135,7 +7135,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}-?\\d{3}$",
+                "eg": "2725-079"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
