### PR TITLE
Adding postal code constraint and example for Reunion

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7227,7 +7227,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^9[78]4\\d{2}$",
+                "eg": "97400"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
