### PR TITLE
Adding postal code constraint and example for Saint Helena

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -7635,7 +7635,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^(ASCN|STHL)[ ]?1ZZ$",
+                "eg": "STHL 1ZZ"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
