### PR TITLE
Adding postal code constraint and example for Svalbard and Jan Mayen

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -8667,7 +8667,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^\\d{4}$",
+                "eg": "9170"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
