### PR TITLE
Adding postal code constraint and example for Wallis and Futuna

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -10310,7 +10310,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^986\\d{2}$",
+                "eg": "98600"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
