### PR TITLE
Adding postal code constraint and example for Mayotte

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -5714,7 +5714,9 @@
           "locality": [
             {
               "postalcode": {
-                "label": "Postal code"
+                "label": "Postal code",
+                "format": "^976\\d{2}$",
+                "eg": "97600"
               }
             },
             {


### PR DESCRIPTION
Pulling in updates based on research by Commerce Guys, taking cues from Google's i18n Lib Address Input.
