### PR TITLE
Remove the "City" field from Singapore.

### DIFF
--- a/src/addressfield.json
+++ b/src/addressfield.json
@@ -8037,11 +8037,6 @@
         {
           "locality": [
             {
-              "localityname": {
-                "label": "City"
-              }
-            },
-            {
               "postalcode": {
                 "label": "Postal code",
                 "format": "^\\d{6}$",


### PR DESCRIPTION
Since **Singapore** is a *city-state* there are no cities in there, hence the *City* field is confusing and unnecessary.